### PR TITLE
Add advanced training objectives and theoretical analysis tools

### DIFF
--- a/experiments/theory/convergence_proofs.py
+++ b/experiments/theory/convergence_proofs.py
@@ -1,0 +1,224 @@
+"""Convergence validation experiments for the unified model."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+
+class ConvergenceValidator:
+    """Empirically validate theoretical convergence properties."""
+
+    def __init__(self, model: Any, device: str = "cuda") -> None:
+        self.model = model.to(device)
+        self.device = device
+
+    def test_contraction_property(self, num_samples: int = 100) -> Dict[str, float]:
+        """Test if dynamics are contractive."""
+
+        print("Testing contraction property...")
+
+        lipschitz_constants = []
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_samples)):
+                z1 = torch.randn(1, self.model.d_model, device=self.device)
+                z2 = torch.randn(1, self.model.d_model, device=self.device)
+
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                f_z1 = self.model.dynamics(z1, context, self.model.memory_patterns)
+                f_z2 = self.model.dynamics(z2, context, self.model.memory_patterns)
+
+                numerator = torch.norm(f_z1 - f_z2)
+                denominator = torch.norm(z1 - z2)
+
+                if denominator > 1e-6:
+                    lipschitz_constants.append((numerator / denominator).item())
+
+        mean_L = float(np.mean(lipschitz_constants)) if lipschitz_constants else float("nan")
+        max_L = float(np.max(lipschitz_constants)) if lipschitz_constants else float("nan")
+        pct_contractive = float(np.mean([L < 1.0 for L in lipschitz_constants])) if lipschitz_constants else 0.0
+
+        print(f"Lipschitz constant: mean={mean_L:.4f}, max={max_L:.4f}")
+        print(f"Contractive: {pct_contractive:.1%} of samples")
+
+        return {
+            "mean_lipschitz": mean_L,
+            "max_lipschitz": max_L,
+            "contractive_percentage": pct_contractive,
+            "is_contraction": max_L < 1.0 if lipschitz_constants else False,
+        }
+
+    def test_energy_descent(
+        self, num_trajectories: int = 50, num_steps: int = 30
+    ) -> Dict[str, Any]:
+        """Verify that energy decreases along trajectories."""
+
+        print("Testing energy descent property...")
+
+        descent_violations = 0
+        energy_trajectories = []
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_trajectories)):
+                z = torch.randn(1, self.model.d_model, device=self.device)
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                energies = []
+
+                for _ in range(num_steps):
+                    z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                    E, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+                    energies.append(E.item())
+                    z = z_next
+
+                energy_trajectories.append(energies)
+
+                for i in range(len(energies) - 1):
+                    if energies[i + 1] > energies[i] + 1e-4:
+                        descent_violations += 1
+                        break
+
+        violation_rate = descent_violations / max(1, num_trajectories)
+
+        print(f"Energy descent violations: {violation_rate:.1%}")
+
+        plt.figure(figsize=(10, 6))
+        for traj in energy_trajectories[:10]:
+            plt.plot(traj, alpha=0.5)
+        plt.xlabel("Iteration")
+        plt.ylabel("Energy")
+        plt.title("Energy Trajectories")
+        plt.savefig("energy_descent.png")
+
+        return {
+            "violation_rate": violation_rate,
+            "energy_trajectories": energy_trajectories,
+            "monotonic_descent": violation_rate < 0.1,
+        }
+
+    def test_fixed_point_stability(
+        self, num_fixed_points: int = 20, num_perturbations: int = 10
+    ) -> Dict[str, Any]:
+        """Test stability of converged fixed points."""
+
+        print("Testing fixed-point stability...")
+
+        stable_count = 0
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_fixed_points)):
+                z_init = torch.randn(1, self.model.d_model, device=self.device)
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                z_eq, info = self.model.solver.solve(z_init, context, self.model.memory_patterns)
+
+                if not info.get("converged", False):
+                    continue
+
+                is_stable = True
+
+                for _ in range(num_perturbations):
+                    epsilon = 0.01
+                    perturbation = epsilon * torch.randn_like(z_eq)
+                    z_perturbed = z_eq + perturbation
+
+                    z_reconverged, _ = self.model.solver.solve(
+                        z_perturbed, context, self.model.memory_patterns
+                    )
+
+                    distance = torch.norm(z_reconverged - z_eq)
+
+                    if distance > 0.1:
+                        is_stable = False
+                        break
+
+                if is_stable:
+                    stable_count += 1
+
+        stability_rate = stable_count / max(1, num_fixed_points)
+
+        print(f"Stable fixed points: {stability_rate:.1%}")
+
+        return {
+            "stability_rate": stability_rate,
+            "is_stable": stability_rate > 0.8,
+        }
+
+    def test_lyapunov_function(self, num_samples: int = 50) -> Dict[str, Any]:
+        """Verify energy function acts as Lyapunov function."""
+
+        print("Testing Lyapunov property...")
+
+        lyapunov_satisfied = 0
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_samples)):
+                z = torch.randn(1, self.model.d_model, device=self.device)
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                is_lyapunov = True
+
+                for _ in range(20):
+                    z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+
+                    E_current, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+                    E_next, _ = self.model.energy_fn(z_next, z_next, self.model.memory_patterns)
+
+                    if E_next > E_current + 1e-4:
+                        is_lyapunov = False
+                        break
+
+                    if torch.norm(z_next - z) < 1e-3:
+                        break
+
+                    z = z_next
+
+                if is_lyapunov:
+                    lyapunov_satisfied += 1
+
+        lyapunov_rate = lyapunov_satisfied / max(1, num_samples)
+
+        print(f"Lyapunov property satisfied: {lyapunov_rate:.1%}")
+
+        return {
+            "lyapunov_rate": lyapunov_rate,
+            "is_lyapunov": lyapunov_rate > 0.9,
+        }
+
+    def run_all_tests(self) -> Dict[str, Dict[str, Any]]:
+        """Run complete convergence validation suite."""
+
+        print("=" * 50)
+        print("CONVERGENCE VALIDATION SUITE")
+        print("=" * 50)
+
+        results = {}
+
+        results["contraction"] = self.test_contraction_property()
+        results["energy_descent"] = self.test_energy_descent()
+        results["stability"] = self.test_fixed_point_stability()
+        results["lyapunov"] = self.test_lyapunov_function()
+
+        all_pass = (
+            results["contraction"]["is_contraction"]
+            and results["energy_descent"]["monotonic_descent"]
+            and results["stability"]["is_stable"]
+            and results["lyapunov"]["is_lyapunov"]
+        )
+
+        print("\n" + "=" * 50)
+        print("SUMMARY")
+        print("=" * 50)
+        print(f"Contraction: {'✓' if results['contraction']['is_contraction'] else '✗'}")
+        print(f"Energy Descent: {'✓' if results['energy_descent']['monotonic_descent'] else '✗'}")
+        print(f"Stability: {'✓' if results['stability']['is_stable'] else '✗'}")
+        print(f"Lyapunov: {'✓' if results['lyapunov']['is_lyapunov'] else '✗'}")
+        print(f"\nOverall: {'✓ ALL TESTS PASSED' if all_pass else '✗ SOME TESTS FAILED'}")
+        print("=" * 50)
+
+        return results

--- a/experiments/theory/energy_analysis.py
+++ b/experiments/theory/energy_analysis.py
@@ -1,0 +1,426 @@
+"""Energy landscape analysis utilities for the unified model."""
+from __future__ import annotations
+
+import importlib
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from tqdm.auto import tqdm
+
+plotly_spec = importlib.util.find_spec("plotly.graph_objects")
+go = importlib.import_module("plotly.graph_objects") if plotly_spec is not None else None
+
+sklearn_decomp_spec = importlib.util.find_spec("sklearn.decomposition")
+if sklearn_decomp_spec is not None:
+    sklearn_decomp = importlib.import_module("sklearn.decomposition")
+    PCA = getattr(sklearn_decomp, "PCA")
+else:
+    PCA = None
+
+sklearn_manifold_spec = importlib.util.find_spec("sklearn.manifold")
+if sklearn_manifold_spec is not None:
+    sklearn_manifold = importlib.import_module("sklearn.manifold")
+    TSNE = getattr(sklearn_manifold, "TSNE")
+else:
+    TSNE = None
+
+sklearn_cluster_spec = importlib.util.find_spec("sklearn.cluster")
+if sklearn_cluster_spec is not None:
+    sklearn_cluster = importlib.import_module("sklearn.cluster")
+    KMeans = getattr(sklearn_cluster, "KMeans")
+else:
+    KMeans = None
+
+
+class EnergyLandscapeAnalyzer:
+    """Visualize and analyze the energy landscape of the unified model."""
+
+    def __init__(self, model: Any, device: str = "cuda") -> None:
+        self.model = model.to(device)
+        self.device = device
+
+    def _require_module(self, module: Optional[Any], name: str) -> Any:
+        if module is None:
+            raise ImportError(
+                f"Optional dependency '{name}' is required for this analysis but is not installed."
+            )
+        return module
+
+    def visualize_2d_slice(
+        self,
+        z_equilibrium: torch.Tensor,
+        context: torch.Tensor,
+        basis_vectors: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+        resolution: int = 50,
+        radius: float = 2.0,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Visualize 2D slice of energy landscape around an equilibrium."""
+
+        print("Computing 2D energy slice...")
+
+        PCA_module = self._require_module(PCA, "sklearn.decomposition.PCA")
+        go_module = self._require_module(go, "plotly.graph_objects")
+
+        if basis_vectors is None:
+            patterns = self.model.memory_patterns.cpu().numpy()
+            pca = PCA_module(n_components=2)
+            pca.fit(patterns)
+            v1 = torch.tensor(pca.components_[0], device=self.device, dtype=torch.float32)
+            v2 = torch.tensor(pca.components_[1], device=self.device, dtype=torch.float32)
+        else:
+            v1, v2 = basis_vectors
+
+        alpha = np.linspace(-radius, radius, resolution)
+        beta = np.linspace(-radius, radius, resolution)
+        A, B = np.meshgrid(alpha, beta)
+
+        energies = np.zeros_like(A)
+        fp_residuals = np.zeros_like(A)
+
+        with torch.no_grad():
+            for i in tqdm(range(resolution)):
+                for j in range(resolution):
+                    z = z_equilibrium + A[i, j] * v1 + B[i, j] * v2
+                    z = z.unsqueeze(0)
+
+                    z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                    E, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+
+                    energies[i, j] = E.item()
+                    fp_residuals[i, j] = torch.norm(z - z_next).item()
+
+        fig = go_module.Figure()
+        fig.add_trace(
+            go_module.Surface(
+                x=A,
+                y=B,
+                z=energies,
+                colorscale="Viridis",
+                name="Energy",
+                showscale=True,
+                opacity=0.9,
+            )
+        )
+
+        fig.add_trace(
+            go_module.Scatter3d(
+                x=[0],
+                y=[0],
+                z=[energies[resolution // 2, resolution // 2]],
+                mode="markers",
+                marker=dict(size=10, color="red"),
+                name="Equilibrium",
+            )
+        )
+
+        fig.update_layout(
+            title="Energy Landscape (2D Slice)",
+            scene=dict(
+                xaxis_title="Direction 1",
+                yaxis_title="Direction 2",
+                zaxis_title="Energy",
+            ),
+            width=900,
+            height=700,
+        )
+
+        fig.write_html("energy_landscape_2d.html")
+        print("Saved to energy_landscape_2d.html")
+
+        fig2, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+        im1 = ax1.contourf(A, B, energies, levels=20, cmap="viridis")
+        ax1.set_title("Energy Landscape")
+        ax1.set_xlabel("Direction 1")
+        ax1.set_ylabel("Direction 2")
+        ax1.plot(0, 0, "r*", markersize=15, label="Equilibrium")
+        ax1.legend()
+        plt.colorbar(im1, ax=ax1)
+
+        im2 = ax2.contourf(A, B, fp_residuals, levels=20, cmap="plasma")
+        ax2.set_title("Fixed-Point Residual")
+        ax2.set_xlabel("Direction 1")
+        ax2.set_ylabel("Direction 2")
+        ax2.plot(0, 0, "r*", markersize=15)
+        plt.colorbar(im2, ax=ax2)
+
+        plt.tight_layout()
+        plt.savefig("energy_landscape_contours.png", dpi=150)
+        print("Saved to energy_landscape_contours.png")
+
+        return energies, fp_residuals
+
+    def visualize_convergence_trajectories(
+        self,
+        num_trajectories: int = 10,
+        num_steps: int = 50,
+    ) -> Tuple[List[np.ndarray], List[List[float]]]:
+        """Visualize multiple convergence trajectories in state space."""
+
+        print("Computing convergence trajectories...")
+
+        PCA_module = self._require_module(PCA, "sklearn.decomposition.PCA")
+
+        trajectories: List[np.ndarray] = []
+        energies_list: List[List[float]] = []
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_trajectories)):
+                z = torch.randn(1, self.model.d_model, device=self.device)
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                traj = [z.cpu().numpy().flatten()]
+                energies: List[float] = []
+
+                for _ in range(num_steps):
+                    z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                    E, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+
+                    traj.append(z_next.cpu().numpy().flatten())
+                    energies.append(E.item())
+
+                    if torch.norm(z_next - z) < 1e-4:
+                        break
+
+                    z = z_next
+
+                trajectories.append(np.array(traj))
+                energies_list.append(energies)
+
+        all_points = np.vstack(trajectories)
+        pca = PCA_module(n_components=2)
+        all_points_2d = pca.fit_transform(all_points)
+
+        trajectories_2d: List[np.ndarray] = []
+        idx = 0
+        for traj in trajectories:
+            traj_len = len(traj)
+            trajectories_2d.append(all_points_2d[idx : idx + traj_len])
+            idx += traj_len
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 7))
+
+        for traj_2d in trajectories_2d:
+            ax1.plot(traj_2d[:, 0], traj_2d[:, 1], "o-", alpha=0.6, markersize=3)
+            ax1.plot(traj_2d[0, 0], traj_2d[0, 1], "go", markersize=8)
+            ax1.plot(traj_2d[-1, 0], traj_2d[-1, 1], "r*", markersize=12)
+
+        ax1.set_title("Convergence Trajectories (PCA projection)")
+        ax1.set_xlabel("PC1")
+        ax1.set_ylabel("PC2")
+        ax1.grid(True, alpha=0.3)
+
+        for energies in energies_list:
+            ax2.plot(energies, alpha=0.6)
+
+        ax2.set_title("Energy During Convergence")
+        ax2.set_xlabel("Iteration")
+        ax2.set_ylabel("Energy")
+        ax2.grid(True, alpha=0.3)
+
+        plt.tight_layout()
+        plt.savefig("convergence_trajectories.png", dpi=150)
+        print("Saved to convergence_trajectories.png")
+
+        return trajectories_2d, energies_list
+
+    def visualize_basin_of_attraction(
+        self,
+        z_equilibrium: torch.Tensor,
+        context: torch.Tensor,
+        resolution: int = 30,
+        radius: float = 3.0,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Identify and visualize basin of attraction around an equilibrium."""
+
+        print("Analyzing basin of attraction...")
+
+        PCA_module = self._require_module(PCA, "sklearn.decomposition.PCA")
+
+        patterns = self.model.memory_patterns.cpu().numpy()
+        pca = PCA_module(n_components=2)
+        pca.fit(patterns)
+        v1 = torch.tensor(pca.components_[0], device=self.device, dtype=torch.float32)
+        v2 = torch.tensor(pca.components_[1], device=self.device, dtype=torch.float32)
+
+        alpha = np.linspace(-radius, radius, resolution)
+        beta = np.linspace(-radius, radius, resolution)
+        A, B = np.meshgrid(alpha, beta)
+
+        convergence_map = np.zeros_like(A)
+        final_energies = np.zeros_like(A)
+
+        with torch.no_grad():
+            for i in tqdm(range(resolution)):
+                for j in range(resolution):
+                    z_init = z_equilibrium + A[i, j] * v1 + B[i, j] * v2
+                    z_init = z_init.unsqueeze(0)
+
+                    z_final, info = self.model.solver.solve(
+                        z_init, context, self.model.memory_patterns
+                    )
+
+                    convergence_map[i, j] = 1 if info.get("converged", False) else 0
+                    final_energies[i, j] = info.get("final_energy", np.nan)
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))
+
+        ax1.contourf(A, B, convergence_map, levels=[-0.5, 0.5, 1.5], colors=["red", "green"], alpha=0.6)
+        ax1.set_title("Basin of Attraction\n(Green = Converged, Red = Failed)")
+        ax1.set_xlabel("Direction 1")
+        ax1.set_ylabel("Direction 2")
+        ax1.plot(0, 0, "k*", markersize=15, label="Target Equilibrium")
+        ax1.legend()
+
+        im2 = ax2.contourf(A, B, final_energies, levels=20, cmap="viridis")
+        ax2.set_title("Final Energy Values")
+        ax2.set_xlabel("Direction 1")
+        ax2.set_ylabel("Direction 2")
+        ax2.plot(0, 0, "r*", markersize=15)
+        plt.colorbar(im2, ax=ax2)
+
+        plt.tight_layout()
+        plt.savefig("basin_of_attraction.png", dpi=150)
+        print("Saved to basin_of_attraction.png")
+
+        convergence_rate = float(convergence_map.mean())
+        print(f"Convergence rate in explored region: {convergence_rate:.1%}")
+
+        return convergence_map, final_energies
+
+    def visualize_memory_organization(self) -> Tuple[np.ndarray, np.ndarray]:
+        """Visualize how memory patterns are organized in state space."""
+
+        print("Visualizing memory organization...")
+
+        TSNE_module = self._require_module(TSNE, "sklearn.manifold.TSNE")
+
+        patterns = self.model.memory_patterns.cpu().numpy()
+
+        tsne = TSNE_module(n_components=2, random_state=42)
+        patterns_2d = tsne.fit_transform(patterns)
+
+        with torch.no_grad():
+            similarities = torch.matmul(
+                self.model.memory_patterns, self.model.memory_patterns.T
+            ).cpu().numpy()
+
+        fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(16, 7))
+
+        ax1.scatter(
+            patterns_2d[:, 0],
+            patterns_2d[:, 1],
+            c=np.arange(len(patterns)),
+            cmap="tab20",
+            alpha=0.6,
+        )
+        ax1.set_title("Memory Pattern Organization (t-SNE)")
+        ax1.set_xlabel("t-SNE 1")
+        ax1.set_ylabel("t-SNE 2")
+
+        im = ax2.imshow(similarities, cmap="viridis", aspect="auto")
+        ax2.set_title("Memory Pattern Similarity Matrix")
+        ax2.set_xlabel("Pattern Index")
+        ax2.set_ylabel("Pattern Index")
+        plt.colorbar(im, ax=ax2)
+
+        plt.tight_layout()
+        plt.savefig("memory_organization.png", dpi=150)
+        print("Saved to memory_organization.png")
+
+        KMeans_module = KMeans
+        if KMeans_module is not None:
+            n_clusters = min(10, max(1, len(patterns) // 100))
+            if n_clusters > 1:
+                kmeans = KMeans_module(n_clusters=n_clusters, random_state=42)
+                clusters = kmeans.fit_predict(patterns)
+
+                print("\nMemory clustering ({} clusters):".format(n_clusters))
+                for i in range(n_clusters):
+                    count = int((clusters == i).sum())
+                    print(f"  Cluster {i}: {count} patterns ({count / len(patterns):.1%})")
+
+        return patterns_2d, similarities
+
+    def analyze_critical_points(self, num_samples: int = 100) -> List[Dict[str, Any]]:
+        """Find and classify critical points of the energy function."""
+
+        print("Analyzing critical points...")
+
+        critical_points: List[Dict[str, Any]] = []
+
+        with torch.no_grad():
+            for _ in tqdm(range(num_samples)):
+                z = torch.randn(1, self.model.d_model, device=self.device)
+                context = torch.randn(1, 10, self.model.d_model, device=self.device)
+
+                z_eq, info = self.model.solver.solve(z, context, self.model.memory_patterns)
+
+                if not info.get("converged", False):
+                    continue
+
+                grad_norm = torch.norm(
+                    self.model.energy_fn.energy_gradient(z_eq, self.model.memory_patterns)
+                ).item()
+
+                eigenvalues = self._estimate_hessian_eigenvalues(z_eq, context)
+
+                critical_points.append(
+                    {
+                        "position": z_eq.cpu().numpy(),
+                        "energy": info.get("final_energy"),
+                        "grad_norm": grad_norm,
+                        "eigenvalues": eigenvalues,
+                        "type": self._classify_critical_point(eigenvalues),
+                    }
+                )
+
+        types = [cp["type"] for cp in critical_points]
+        type_counts = {t: types.count(t) for t in set(types)}
+
+        print("\nCritical Point Analysis:")
+        for cp_type, count in type_counts.items():
+            print(f"  {cp_type}: {count} ({count / len(critical_points):.1%})")
+
+        return critical_points
+
+    def _estimate_hessian_eigenvalues(
+        self,
+        z: torch.Tensor,
+        context: torch.Tensor,
+        num_samples: int = 5,
+    ) -> List[float]:
+        """Estimate Hessian eigenvalues using finite differences."""
+
+        eigenvalues: List[float] = []
+
+        with torch.enable_grad():
+            for _ in range(num_samples):
+                v = torch.randn_like(z)
+                v = v / torch.norm(v)
+
+                z_param = z.detach().requires_grad_(True)
+                z_next = self.model.dynamics(z_param, context, self.model.memory_patterns)
+                E, _ = self.model.energy_fn(z_param, z_next, self.model.memory_patterns)
+
+                grad_E = torch.autograd.grad(E, z_param, create_graph=True)[0]
+                Hv = torch.autograd.grad(grad_E, z_param, v, retain_graph=False)[0]
+
+                eigenval = (v * Hv).sum().item()
+                eigenvalues.append(eigenval)
+
+        return eigenvalues
+
+    def _classify_critical_point(self, eigenvalues: Sequence[float]) -> str:
+        """Classify critical point based on Hessian eigenvalues."""
+
+        pos = sum(1 for e in eigenvalues if e > 0.01)
+        neg = sum(1 for e in eigenvalues if e < -0.01)
+
+        if pos == len(eigenvalues):
+            return "Minimum (Stable)"
+        if neg == len(eigenvalues):
+            return "Maximum (Unstable)"
+        return "Saddle Point"

--- a/src/training/objectives.py
+++ b/src/training/objectives.py
@@ -1,0 +1,120 @@
+"""Training objectives for unified model."""
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+# Optional dependency: wandb is referenced in other modules, but not here.
+# Silence lint warnings about unused imports if module unavailable.
+
+
+class UnifiedTrainingObjective:
+    """Multi-component loss function for training the unified model."""
+
+    def __init__(
+        self,
+        task_weight: float = 1.0,
+        energy_weight: float = 0.1,
+        convergence_weight: float = 0.05,
+        stability_weight: float = 0.01,
+        contraction_target: float = 0.9,
+    ) -> None:
+        self.w_task = task_weight
+        self.w_energy = energy_weight
+        self.w_conv = convergence_weight
+        self.w_stab = stability_weight
+        self.contraction_target = contraction_target
+
+    def compute_loss(
+        self,
+        model: Any,
+        batch: Tuple[torch.Tensor, torch.Tensor],
+        diagnostics: Dict[str, Any],
+    ) -> Tuple[torch.Tensor, Dict[str, Any]]:
+        """Compute full training loss."""
+
+        input_ids, target_ids = batch
+        logits = diagnostics.get("logits")
+        if logits is None:
+            logits = model(input_ids)
+
+        loss_task = F.cross_entropy(
+            logits.view(-1, logits.size(-1)),
+            target_ids.view(-1),
+            ignore_index=-100,
+        )
+
+        solver_info = diagnostics.get("solver_info", {})
+        final_energy = solver_info.get("final_energy", torch.tensor(0.0, device=loss_task.device))
+        energy_components = solver_info.get("energy_components", {})
+
+        loss_energy = self.w_energy * final_energy
+
+        num_iterations = solver_info.get("iterations", 0)
+        max_iter = getattr(model.solver, "max_iter", 1) or 1
+        loss_convergence = self.w_conv * (num_iterations / max_iter)
+
+        z_eq = diagnostics.get("z_equilibrium")
+        lipschitz_const = 0.0
+        if z_eq is not None:
+            lipschitz_const = self._estimate_lipschitz(model, z_eq, diagnostics)
+
+        loss_stability = self.w_stab * F.relu(
+            torch.as_tensor(lipschitz_const, device=loss_task.device) - self.contraction_target
+        )
+
+        total_loss = loss_task + loss_energy + loss_convergence + loss_stability
+
+        loss_components = {
+            "total": float(total_loss.detach().item()),
+            "task": float(loss_task.detach().item()),
+            "energy": float(loss_energy.detach().item()) if isinstance(loss_energy, torch.Tensor) else loss_energy,
+            "convergence": float(loss_convergence.detach().item())
+            if isinstance(loss_convergence, torch.Tensor)
+            else loss_convergence,
+            "stability": float(loss_stability.detach().item())
+            if isinstance(loss_stability, torch.Tensor)
+            else loss_stability,
+            "num_iterations": num_iterations,
+            "lipschitz_constant": lipschitz_const,
+            "energy_components": energy_components,
+        }
+
+        return total_loss, loss_components
+
+    def _estimate_lipschitz(
+        self,
+        model: Any,
+        z_equilibrium: torch.Tensor,
+        diagnostics: Dict[str, Any],
+        num_samples: int = 5,
+    ) -> float:
+        """Estimate Lipschitz constant of dynamics via sampling."""
+
+        context = diagnostics.get("context")
+        if context is None:
+            return 0.0
+
+        with torch.no_grad():
+            lipschitz_estimates = []
+
+            for _ in range(num_samples):
+                epsilon = 0.01
+                delta = epsilon * torch.randn_like(z_equilibrium)
+                z_perturbed = z_equilibrium + delta
+
+                f_z = model.dynamics(z_equilibrium, context, model.memory_patterns)
+                f_z_pert = model.dynamics(z_perturbed, context, model.memory_patterns)
+
+                numerator = torch.norm(f_z_pert - f_z, dim=-1).mean()
+                denominator = torch.norm(delta, dim=-1).mean().clamp_min(1e-8)
+
+                lipschitz_estimates.append((numerator / denominator).item())
+
+        if not lipschitz_estimates:
+            return 0.0
+
+        return float(np.mean(lipschitz_estimates))

--- a/src/training/trainer.py
+++ b/src/training/trainer.py
@@ -1,0 +1,209 @@
+"""Curriculum-based training loop for the unified model."""
+from __future__ import annotations
+
+import importlib
+from typing import Any, Dict, Tuple
+
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+from tqdm.auto import tqdm
+
+wandb_spec = importlib.util.find_spec("wandb")
+wandb = importlib.import_module("wandb") if wandb_spec is not None else None
+
+
+class UnifiedModelTrainer:
+    """Training loop with curriculum learning for stable DEQ training."""
+
+    def __init__(
+        self,
+        model: Any,
+        optimizer: torch.optim.Optimizer,
+        train_loader: DataLoader,
+        val_loader: DataLoader,
+        objective: Any,
+        device: str = "cuda",
+        log_wandb: bool = True,
+    ) -> None:
+        self.model = model.to(device)
+        self.optimizer = optimizer
+        self.train_loader = train_loader
+        self.val_loader = val_loader
+        self.objective = objective
+        self.device = device
+        self.log_wandb = log_wandb and wandb is not None
+
+        self.step = 0
+        self.epoch = 0
+
+        self.curriculum = {
+            "warmup_steps": 1000,
+            "max_iter_schedule": [5, 10, 20, 30],
+            "tolerance_schedule": [1e-2, 5e-3, 1e-3, 5e-4],
+            "memory_enable_step": 2000,
+        }
+
+    def get_curriculum_params(self) -> Tuple[int, float, bool]:
+        """Get current curriculum parameters based on training step."""
+
+        if self.step < self.curriculum["warmup_steps"]:
+            max_iter = self.curriculum["max_iter_schedule"][0]
+            tolerance = self.curriculum["tolerance_schedule"][0]
+        else:
+            stage = min(
+                len(self.curriculum["max_iter_schedule"]) - 1,
+                (self.step - self.curriculum["warmup_steps"]) // 2000,
+            )
+            max_iter = self.curriculum["max_iter_schedule"][stage]
+            tolerance = self.curriculum["tolerance_schedule"][stage]
+
+        memory_enabled = self.step >= self.curriculum["memory_enable_step"]
+
+        return max_iter, tolerance, memory_enabled
+
+    def train_step(self, batch: Tuple[torch.Tensor, torch.Tensor]) -> Dict[str, Any]:
+        """Single training step with curriculum adjustments."""
+
+        self.model.train()
+
+        max_iter, tolerance, memory_enabled = self.get_curriculum_params()
+
+        self.model.solver.max_iter = max_iter
+        self.model.solver.tol_fp = tolerance
+        self.model.solver.tol_energy = tolerance
+
+        input_ids, target_ids = batch
+        input_ids = input_ids.to(self.device)
+        target_ids = target_ids.to(self.device)
+
+        logits, diagnostics = self.model(
+            input_ids,
+            update_memory=memory_enabled,
+            return_diagnostics=True,
+        )
+        diagnostics["logits"] = logits
+
+        loss, loss_components = self.objective.compute_loss(
+            self.model,
+            (input_ids, target_ids),
+            diagnostics,
+        )
+
+        self.optimizer.zero_grad()
+        loss.backward()
+
+        torch.nn.utils.clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+
+        self.optimizer.step()
+
+        if self.log_wandb and self.step % 10 == 0:
+            wandb.log(
+                {
+                    **loss_components,
+                    "curriculum/max_iter": max_iter,
+                    "curriculum/tolerance": tolerance,
+                    "curriculum/memory_enabled": int(memory_enabled),
+                    "step": self.step,
+                }
+            )
+
+        self.step += 1
+
+        return loss_components
+
+    def validate(self) -> Dict[str, float]:
+        """Validation loop with detailed diagnostics."""
+
+        self.model.eval()
+
+        total_loss = 0.0
+        total_converged = 0
+        total_iterations = []
+
+        with torch.no_grad():
+            for batch in self.val_loader:
+                input_ids, target_ids = batch
+                input_ids = input_ids.to(self.device)
+                target_ids = target_ids.to(self.device)
+
+                logits, diagnostics = self.model(
+                    input_ids,
+                    update_memory=False,
+                    return_diagnostics=True,
+                )
+                diagnostics["logits"] = logits
+
+                loss, loss_components = self.objective.compute_loss(
+                    self.model,
+                    (input_ids, target_ids),
+                    diagnostics,
+                )
+
+                total_loss += float(loss.detach().item())
+                solver_info = diagnostics.get("solver_info", {})
+                total_converged += int(solver_info.get("converged", False))
+                total_iterations.append(solver_info.get("iterations", 0))
+
+        num_batches = max(1, len(self.val_loader))
+        val_stats = {
+            "val/loss": total_loss / num_batches,
+            "val/convergence_rate": total_converged / num_batches,
+            "val/avg_iterations": float(np.mean(total_iterations)) if total_iterations else 0.0,
+            "val/median_iterations": float(np.median(total_iterations)) if total_iterations else 0.0,
+            "val/max_iterations": float(np.max(total_iterations)) if total_iterations else 0.0,
+        }
+
+        if self.log_wandb:
+            wandb.log(val_stats)
+
+        return val_stats
+
+    def train(self, num_epochs: int) -> None:
+        """Full training loop with validation and checkpointing."""
+
+        for epoch in range(num_epochs):
+            self.epoch = epoch
+            print(f"\nEpoch {epoch + 1}/{num_epochs}")
+
+            for batch_idx, batch in enumerate(tqdm(self.train_loader)):
+                loss_components = self.train_step(batch)
+
+                if self.step % 500 == 0:
+                    val_stats = self.validate()
+                    print(
+                        f"Step {self.step}: Val Loss = {val_stats['val/loss']:.4f}, "
+                        f"Convergence = {val_stats['val/convergence_rate']:.2%}"
+                    )
+
+            val_stats = self.validate()
+
+            if (epoch + 1) % 5 == 0:
+                self.save_checkpoint(f"checkpoint_epoch_{epoch + 1}.pt")
+
+        print("Training complete!")
+
+    def save_checkpoint(self, path: str) -> None:
+        """Save model checkpoint with training state."""
+
+        torch.save(
+            {
+                "model_state_dict": self.model.state_dict(),
+                "optimizer_state_dict": self.optimizer.state_dict(),
+                "step": self.step,
+                "epoch": self.epoch,
+                "memory_patterns": getattr(self.model, "memory_patterns", None),
+            },
+            path,
+        )
+
+    def load_checkpoint(self, path: str) -> None:
+        """Load model checkpoint."""
+
+        checkpoint = torch.load(path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.step = checkpoint.get("step", 0)
+        self.epoch = checkpoint.get("epoch", 0)
+        if "memory_patterns" in checkpoint:
+            self.model.memory_patterns = checkpoint["memory_patterns"]


### PR DESCRIPTION
## Summary
- add a unified training objective that blends task loss with energy, convergence, and stability regularization
- implement a curriculum-aware trainer that tunes solver limits, supports memory gating, and integrates logging and checkpointing
- create convergence validation and energy landscape analysis utilities for theoretical experimentation

## Testing
- python -m compileall src experiments

------
https://chatgpt.com/codex/tasks/task_e_68df400dbdac832bbcc4bb83f5cacd5b