### PR TITLE
Add theoretical validation experiment utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The development roadmap follows ten sequential phases:
 3. Unified dynamics integrating Mamba-style state-space updates with Hopfield retrieval *(completed)*
 4. Hybrid equilibrium solver supporting alternating, simultaneous, and cascade modes *(completed)*
 5. Full model assembly with implicit-depth wrapper *(completed)*
-6. Training infrastructure with curriculum learning for energy-based objectives
+6. Training infrastructure with curriculum learning for energy-based objectives *(completed)*
 7. Theoretical validation experiments (convergence, Lyapunov, contraction analyses)
 8. Practical task experiments (associative recall, continual learning benchmarks)
 9. Energy landscape visualization tools

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,70 @@
 # Architecture Overview
 
-A detailed description of the unified model components will be provided here.
+The unified architecture is organised around three interacting subsystems:
+
+1. **Dynamics core** – `src/unified_energy/core/` contains the Mamba-inspired
+   temporal processor, the Hopfield energy functional, and the joint
+   equilibrium solver that enforces both fixed-point and energy optimality.
+2. **Model wrapper** – `src/unified_energy/models/unified.py` assembles the
+   dynamics, solver, and memory bank into a full sequence model capable of
+   iterative equilibrium inference and implicit-gradient backpropagation.
+3. **Training and evaluation tooling** – `src/unified_energy/training/` now
+   provides curriculum-aware training utilities that expose diagnostics needed
+   for energy-based regularisation.
+
+## Training Objective
+
+`UnifiedTrainingObjective` combines four components:
+
+* **Task loss** – standard cross-entropy between logits and targets.
+* **Energy penalty** – encourages equilibria with low unified energy using the
+  solver diagnostics.
+* **Convergence cost** – normalises the solver iteration count to bias the
+  model towards faster fixed-point attainment.
+* **Stability regulariser** – estimates a local Lipschitz constant of the
+  dynamics and penalises departures from the contraction target.
+
+All scalar metrics are surfaced via the returned component dictionary to make
+experiment tracking straightforward.
+
+## Curriculum Trainer
+
+`UnifiedModelTrainer` orchestrates solver parameter schedules, gradient-based
+optimisation, validation, and lightweight checkpointing. Its curriculum
+configuration controls the equilibrium solver depth and tolerance per training
+phase, while optional Weights & Biases logging can be enabled without becoming
+a hard dependency. The helper `train_epoch` function runs a bounded number of
+steps for smoke tests or interactive prototyping.
+
+## Notes for Future Contributors
+
+* The solver diagnostics dictionary now always includes final energy statistics
+  (even when convergence fails) so downstream utilities can rely on a consistent
+  interface.
+* Diagnostics returned from the unified model expose the processed input
+  context, making it easy to compute Jacobian-vector products or additional
+  stability metrics without repeating the forward pass.
+* See `tests/test_training.py` for minimal examples demonstrating how to plug
+  the trainer and objective together with a lightweight dummy model.
+
+## Theoretical Validation Toolkit
+
+The `unified_energy.experiments.theory` package introduces two lightweight
+utilities designed to make the mathematical guarantees of the architecture
+observable in practice:
+
+* `ConvergenceValidator` executes four batteries that mirror the project plan:
+  contraction estimates, monotonic energy descent checks, equilibrium stability
+  perturbations, and Lyapunov-style energy tracking. Results are returned as
+  plain dictionaries so higher level experiment runners (or notebooks) can log
+  summaries without depending on plotting libraries.
+* `EnergyLandscapeAnalyzer` samples two-dimensional slices of the energy
+  surface, collects projected convergence trajectories, inspects basins of
+  attraction, and projects stored memories via PCA. The helper is careful to run
+  entirely on CPU-friendly tensor operations, making it safe to call inside unit
+  tests while still returning NumPy arrays that can be visualised interactively
+  when optional plotting packages are available.
+
+Both utilities require only the public interfaces already exposed by the unified
+model (`dynamics`, `energy_fn`, `solver`, and `memory_patterns`), so they remain
+applicable to future architectural variants.

--- a/src/unified_energy/experiments/__init__.py
+++ b/src/unified_energy/experiments/__init__.py
@@ -1,3 +1,15 @@
-"""Experiment orchestration utilities (to be populated in later phases)."""
+"""Experiment orchestration utilities for the unified energy model."""
 
-__all__: list[str] = []
+from .theory import (
+    ConvergenceValidator,
+    EnergyLandscapeAnalyzer,
+    LandscapeConfig,
+    ValidationConfig,
+)
+
+__all__ = [
+    "ConvergenceValidator",
+    "ValidationConfig",
+    "EnergyLandscapeAnalyzer",
+    "LandscapeConfig",
+]

--- a/src/unified_energy/experiments/theory/__init__.py
+++ b/src/unified_energy/experiments/theory/__init__.py
@@ -1,0 +1,11 @@
+"""Theoretical experiment helpers for validating the unified architecture."""
+
+from .convergence_proofs import ConvergenceValidator, ValidationConfig
+from .energy_analysis import EnergyLandscapeAnalyzer, LandscapeConfig
+
+__all__ = [
+    "ConvergenceValidator",
+    "ValidationConfig",
+    "EnergyLandscapeAnalyzer",
+    "LandscapeConfig",
+]

--- a/src/unified_energy/experiments/theory/convergence_proofs.py
+++ b/src/unified_energy/experiments/theory/convergence_proofs.py
@@ -1,0 +1,215 @@
+"""Empirical validation utilities for the unified equilibrium formulation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import torch
+from torch import Tensor, nn
+
+
+@dataclass(slots=True)
+class ValidationConfig:
+    """Configuration controlling convergence validation sweeps."""
+
+    context_length: int = 8
+    batch_size: int = 1
+    lipschitz_threshold: float = 1.0
+    energy_tolerance: float = 1e-4
+    stability_radius: float = 0.1
+    max_perturbation_trials: int = 5
+
+
+class ConvergenceValidator:
+    """Run sanity checks that mirror the theoretical guarantees in practice."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        *,
+        device: Optional[torch.device | str] = None,
+        config: Optional[ValidationConfig] = None,
+    ) -> None:
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(device)
+        self.model = model.to(self.device) if hasattr(model, "to") else model
+        self.config = config or ValidationConfig()
+        self._d_model = self._infer_hidden_dim()
+
+        if not hasattr(self.model, "dynamics"):
+            msg = "Model must expose a dynamics(z, context, memory_patterns) method"
+            raise ValueError(msg)
+        if not hasattr(self.model, "energy_fn"):
+            msg = "Model must expose an energy_fn compatible with UnifiedEnergyFunction"
+            raise ValueError(msg)
+        if not hasattr(self.model, "solver"):
+            msg = "Model must expose a solver with a solve(...) method"
+            raise ValueError(msg)
+        if not hasattr(self.model, "memory_patterns"):
+            msg = "Model must provide a memory_patterns tensor"
+            raise ValueError(msg)
+
+    # ------------------------------------------------------------------
+    # Core helpers
+    # ------------------------------------------------------------------
+    def _infer_hidden_dim(self) -> int:
+        if hasattr(self.model, "d_model"):
+            return int(getattr(self.model, "d_model"))
+        patterns = getattr(self.model, "memory_patterns", None)
+        if isinstance(patterns, Tensor):
+            return int(patterns.size(-1))
+        raise ValueError("Unable to infer model hidden dimension")
+
+    def _sample_context(self, batch_size: Optional[int] = None) -> Tensor:
+        length = self.config.context_length
+        batch = batch_size or self.config.batch_size
+        return torch.randn(batch, length, self._d_model, device=self.device)
+
+    # ------------------------------------------------------------------
+    # Validation routines
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def test_contraction_property(self, num_samples: int = 32) -> Dict[str, float]:
+        """Estimate the Lipschitz constant of the dynamics."""
+
+        lipschitz_values = []
+        for _ in range(num_samples):
+            z1 = torch.randn(self.config.batch_size, self._d_model, device=self.device)
+            z2 = torch.randn_like(z1)
+            context = self._sample_context()
+            f_z1 = self.model.dynamics(z1, context, self.model.memory_patterns)
+            f_z2 = self.model.dynamics(z2, context, self.model.memory_patterns)
+            numerator = torch.linalg.vector_norm(f_z1 - f_z2)
+            denominator = torch.linalg.vector_norm(z1 - z2).clamp_min(1e-8)
+            lipschitz_values.append((numerator / denominator).item())
+
+        max_lip = max(lipschitz_values)
+        mean_lip = sum(lipschitz_values) / len(lipschitz_values)
+        contractive_ratio = sum(1.0 for v in lipschitz_values if v < 1.0) / len(
+            lipschitz_values
+        )
+        return {
+            "mean_lipschitz": mean_lip,
+            "max_lipschitz": max_lip,
+            "contractive_fraction": contractive_ratio,
+            "is_contractive": max_lip < self.config.lipschitz_threshold,
+        }
+
+    @torch.no_grad()
+    def test_energy_descent(self, num_trajectories: int = 16, num_steps: int = 20) -> Dict[str, float]:
+        """Check that the unified energy decreases along iterative updates."""
+
+        violations = 0
+        for _ in range(num_trajectories):
+            z = torch.randn(self.config.batch_size, self._d_model, device=self.device)
+            context = self._sample_context()
+            last_energy: Optional[float] = None
+            for _ in range(num_steps):
+                z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                energy, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+                energy_value = float(energy.detach())
+                if last_energy is not None and energy_value > last_energy + self.config.energy_tolerance:
+                    violations += 1
+                    break
+                if torch.linalg.vector_norm(z_next - z).item() < self.config.energy_tolerance:
+                    break
+                last_energy = energy_value
+                z = z_next
+        violation_rate = violations / max(1, num_trajectories)
+        return {
+            "violation_rate": violation_rate,
+            "monotonic_descent": violation_rate < 0.2,
+        }
+
+    @torch.no_grad()
+    def test_fixed_point_stability(
+        self, num_fixed_points: int = 8, num_perturbations: Optional[int] = None
+    ) -> Dict[str, float]:
+        """Probe stability of equilibria by perturbing converged states."""
+
+        if num_perturbations is None:
+            num_perturbations = self.config.max_perturbation_trials
+        stable = 0
+        attempted = 0
+        for _ in range(num_fixed_points):
+            z_init = torch.randn(self.config.batch_size, self._d_model, device=self.device)
+            context = self._sample_context()
+            z_eq, info = self.model.solver.solve(z_init, context, self.model.memory_patterns)
+            if not info.get("converged", False):
+                continue
+            attempted += 1
+            equilibrium_stable = True
+            for _ in range(num_perturbations):
+                noise = self.config.stability_radius * torch.randn_like(z_eq)
+                z_perturbed = z_eq + noise
+                z_return, info_return = self.model.solver.solve(
+                    z_perturbed, context, self.model.memory_patterns
+                )
+                if not info_return.get("converged", False):
+                    equilibrium_stable = False
+                    break
+                delta = torch.linalg.vector_norm(z_return - z_eq).item()
+                if delta > self.config.stability_radius * 5:
+                    equilibrium_stable = False
+                    break
+            if equilibrium_stable:
+                stable += 1
+        stability_rate = stable / max(1, attempted)
+        return {
+            "tested_equilibria": attempted,
+            "stability_rate": stability_rate,
+            "is_stable": stability_rate > 0.7,
+        }
+
+    @torch.no_grad()
+    def test_lyapunov_function(self, num_samples: int = 16, horizon: int = 15) -> Dict[str, float]:
+        """Validate that the energy acts as a Lyapunov function for the dynamics."""
+
+        satisfied = 0
+        for _ in range(num_samples):
+            z = torch.randn(self.config.batch_size, self._d_model, device=self.device)
+            context = self._sample_context()
+            is_valid = True
+            prev_energy: Optional[float] = None
+            for _ in range(horizon):
+                z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                energy, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+                energy_val = float(energy.detach())
+                if prev_energy is not None and energy_val > prev_energy + self.config.energy_tolerance:
+                    is_valid = False
+                    break
+                if torch.linalg.vector_norm(z_next - z).item() < self.config.energy_tolerance:
+                    break
+                prev_energy = energy_val
+                z = z_next
+            if is_valid:
+                satisfied += 1
+        lyapunov_rate = satisfied / max(1, num_samples)
+        return {
+            "lyapunov_rate": lyapunov_rate,
+            "is_lyapunov": lyapunov_rate > 0.8,
+        }
+
+    # ------------------------------------------------------------------
+    # Aggregate
+    # ------------------------------------------------------------------
+    def run_all_tests(self) -> Dict[str, Dict[str, float]]:
+        """Execute the entire validation battery and collate metrics."""
+
+        results = {
+            "contraction": self.test_contraction_property(),
+            "energy_descent": self.test_energy_descent(),
+            "stability": self.test_fixed_point_stability(),
+            "lyapunov": self.test_lyapunov_function(),
+        }
+        all_pass = all(
+            (
+                results["contraction"].get("is_contractive", False)
+                and results["energy_descent"].get("monotonic_descent", False)
+                and results["stability"].get("is_stable", False)
+                and results["lyapunov"].get("is_lyapunov", False)
+            )
+        )
+        results["summary"] = {"all_tests_passed": bool(all_pass)}
+        return results

--- a/src/unified_energy/experiments/theory/energy_analysis.py
+++ b/src/unified_energy/experiments/theory/energy_analysis.py
@@ -1,0 +1,293 @@
+"""Energy landscape interrogation utilities."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Tuple
+
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+
+@dataclass(slots=True)
+class LandscapeConfig:
+    """Configuration parameters for landscape sweeps."""
+
+    context_length: int = 8
+    grid_resolution: int = 21
+    exploration_radius: float = 1.5
+    trajectory_steps: int = 20
+    basin_resolution: int = 21
+    basin_radius: float = 2.0
+
+
+class EnergyLandscapeAnalyzer:
+    """Numerically probe the unified model's energy landscape."""
+
+    def __init__(
+        self,
+        model: nn.Module,
+        *,
+        device: Optional[torch.device | str] = None,
+        config: Optional[LandscapeConfig] = None,
+    ) -> None:
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(device)
+        self.model = model.to(self.device) if hasattr(model, "to") else model
+        if not hasattr(self.model, "memory_patterns"):
+            msg = "Model must expose a memory_patterns tensor"
+            raise ValueError(msg)
+        if not hasattr(self.model, "dynamics"):
+            msg = "Model must provide a dynamics(z, context, memory_patterns) method"
+            raise ValueError(msg)
+        if not hasattr(self.model, "energy_fn"):
+            msg = "Model must expose an energy_fn"
+            raise ValueError(msg)
+        if not hasattr(self.model, "solver"):
+            msg = "Model must expose a solver with a solve(...) method"
+            raise ValueError(msg)
+        self.config = config or LandscapeConfig()
+        self._d_model = self._infer_hidden_dim()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _infer_hidden_dim(self) -> int:
+        if hasattr(self.model, "d_model"):
+            return int(getattr(self.model, "d_model"))
+        patterns = getattr(self.model, "memory_patterns", None)
+        if isinstance(patterns, Tensor):
+            return int(patterns.size(-1))
+        raise ValueError("Unable to infer model hidden dimension")
+
+    def _sample_context(self, batch_size: int = 1) -> Tensor:
+        return torch.randn(
+            batch_size,
+            self.config.context_length,
+            self._d_model,
+            device=self.device,
+        )
+
+    def _principal_directions(self) -> Tuple[Tensor, Tensor]:
+        patterns = self.model.memory_patterns.detach().to(self.device)
+        if patterns.numel() == 0:
+            raise ValueError("Memory patterns are empty; unable to derive principal directions")
+        centered = patterns - patterns.mean(dim=0, keepdim=True)
+        cov = centered.t() @ centered / max(1, centered.size(0) - 1)
+        eigvals, eigvecs = torch.linalg.eigh(cov)
+        v1 = eigvecs[:, -1]
+        v2 = eigvecs[:, -2] if eigvecs.size(1) > 1 else torch.randn_like(v1)
+        return v1 / v1.norm(), v2 / v2.norm()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @torch.no_grad()
+    def visualize_2d_slice(
+        self,
+        z_equilibrium: Tensor,
+        context: Optional[Tensor] = None,
+        *,
+        basis_vectors: Optional[Tuple[Tensor, Tensor]] = None,
+        resolution: Optional[int] = None,
+        radius: Optional[float] = None,
+    ) -> Dict[str, np.ndarray]:
+        """Evaluate energy and residuals on a 2D plane around an equilibrium."""
+
+        if z_equilibrium.ndim != 2:
+            raise ValueError("z_equilibrium must have shape (batch, d_model)")
+        if z_equilibrium.size(0) != 1:
+            raise ValueError("Only single-equilibrium visualisation is supported")
+        resolution = resolution or self.config.grid_resolution
+        radius = radius or self.config.exploration_radius
+        if context is None:
+            context = self._sample_context()
+        if basis_vectors is None:
+            basis_vectors = self._principal_directions()
+        v1, v2 = (vec.to(self.device) for vec in basis_vectors)
+        v1 = v1 / v1.norm().clamp_min(1e-8)
+        v2 = v2 / v2.norm().clamp_min(1e-8)
+        alphas = torch.linspace(-radius, radius, resolution, device=self.device)
+        betas = torch.linspace(-radius, radius, resolution, device=self.device)
+        energy_grid = torch.zeros(resolution, resolution, device=self.device)
+        residual_grid = torch.zeros_like(energy_grid)
+        base = z_equilibrium[0]
+        for i, alpha in enumerate(alphas):
+            for j, beta in enumerate(betas):
+                point = base + alpha * v1 + beta * v2
+                point = point.unsqueeze(0)
+                z_next = self.model.dynamics(point, context, self.model.memory_patterns)
+                energy, _ = self.model.energy_fn(point, z_next, self.model.memory_patterns)
+                energy_grid[i, j] = energy.detach()
+                residual_grid[i, j] = torch.linalg.vector_norm(z_next - point)
+        return {
+            "alpha": alphas.cpu().numpy(),
+            "beta": betas.cpu().numpy(),
+            "energy": energy_grid.cpu().numpy(),
+            "residual": residual_grid.cpu().numpy(),
+        }
+
+    @torch.no_grad()
+    def visualize_convergence_trajectories(
+        self,
+        num_trajectories: int = 8,
+        steps: Optional[int] = None,
+    ) -> Dict[str, np.ndarray]:
+        """Collect convergence trajectories and provide a 2D projection."""
+
+        steps = steps or self.config.trajectory_steps
+        trajectories: list[np.ndarray] = []
+        energies: list[np.ndarray] = []
+        for _ in range(num_trajectories):
+            z = torch.randn(1, self._d_model, device=self.device)
+            context = self._sample_context()
+            points = []
+            energy_values = []
+            for _ in range(steps):
+                points.append(z.detach().cpu().numpy())
+                z_next = self.model.dynamics(z, context, self.model.memory_patterns)
+                energy, _ = self.model.energy_fn(z, z_next, self.model.memory_patterns)
+                energy_values.append(float(energy.detach()))
+                if torch.linalg.vector_norm(z_next - z).item() < 1e-4:
+                    z = z_next
+                    break
+                z = z_next
+            trajectories.append(np.concatenate(points, axis=0))
+            energies.append(np.array(energy_values))
+        stacked = np.concatenate(trajectories, axis=0)
+        # Principal component projection
+        stacked_centered = stacked - stacked.mean(axis=0, keepdims=True)
+        u, s, vh = np.linalg.svd(stacked_centered, full_matrices=False)
+        components = vh[:2]
+        projected: list[np.ndarray] = []
+        cursor = 0
+        for traj in trajectories:
+            length = traj.shape[0]
+            segment = stacked_centered[cursor : cursor + length] @ components.T
+            projected.append(segment)
+            cursor += length
+        return {
+            "trajectories_2d": projected,
+            "energy_traces": energies,
+            "components": components,
+        }
+
+    @torch.no_grad()
+    def visualize_basin_of_attraction(
+        self,
+        z_equilibrium: Tensor,
+        context: Optional[Tensor] = None,
+        *,
+        resolution: Optional[int] = None,
+        radius: Optional[float] = None,
+    ) -> Dict[str, np.ndarray]:
+        """Sample a neighbourhood and record convergence success."""
+
+        if z_equilibrium.ndim != 2 or z_equilibrium.size(0) != 1:
+            raise ValueError("z_equilibrium must be of shape (1, d_model)")
+        resolution = resolution or self.config.basin_resolution
+        radius = radius or self.config.basin_radius
+        if context is None:
+            context = self._sample_context()
+        v1, v2 = self._principal_directions()
+        v1 = v1.to(self.device)
+        v2 = v2.to(self.device)
+        alphas = torch.linspace(-radius, radius, resolution, device=self.device)
+        betas = torch.linspace(-radius, radius, resolution, device=self.device)
+        convergence = torch.zeros(resolution, resolution, device=self.device)
+        final_energy = torch.zeros_like(convergence)
+        base = z_equilibrium[0]
+        for i, alpha in enumerate(alphas):
+            for j, beta in enumerate(betas):
+                start = base + alpha * v1 + beta * v2
+                start = start.unsqueeze(0)
+                z_final, info = self.model.solver.solve(start, context, self.model.memory_patterns)
+                success = 1.0 if info.get("converged", False) else 0.0
+                convergence[i, j] = success
+                final_energy[i, j] = float(info.get("final_energy", np.nan))
+        return {
+            "alpha": alphas.cpu().numpy(),
+            "beta": betas.cpu().numpy(),
+            "convergence": convergence.cpu().numpy(),
+            "final_energy": final_energy.cpu().numpy(),
+        }
+
+    @torch.no_grad()
+    def visualize_memory_organization(self) -> Dict[str, np.ndarray]:
+        """Project memory patterns to 2D using PCA and compute similarities."""
+
+        patterns = self.model.memory_patterns.detach().cpu().numpy()
+        if patterns.size == 0:
+            raise ValueError("No memory patterns available for analysis")
+        centered = patterns - patterns.mean(axis=0, keepdims=True)
+        u, s, vh = np.linalg.svd(centered, full_matrices=False)
+        components = vh[:2]
+        patterns_2d = centered @ components.T
+        similarities = patterns @ patterns.T
+        return {
+            "patterns_2d": patterns_2d,
+            "similarities": similarities,
+            "components": components,
+        }
+
+    @torch.no_grad()
+    def analyze_critical_points(
+        self,
+        num_samples: int = 16,
+    ) -> Iterable[Dict[str, float]]:
+        """Identify approximate critical points by converging random initialisations."""
+
+        results = []
+        for _ in range(num_samples):
+            z0 = torch.randn(1, self._d_model, device=self.device)
+            context = self._sample_context()
+            z_eq, info = self.model.solver.solve(z0, context, self.model.memory_patterns)
+            if not info.get("converged", False):
+                continue
+            grad = self.model.energy_fn.energy_gradient(z_eq, self.model.memory_patterns)
+            grad_norm = float(torch.linalg.vector_norm(grad))
+            eigenvalues = self._estimate_hessian_eigs(z_eq, context)
+            point_type = self._classify_eigenvalues(eigenvalues)
+            results.append(
+                {
+                    "final_energy": float(info.get("final_energy", np.nan)),
+                    "grad_norm": grad_norm,
+                    "type": point_type,
+                }
+            )
+        return results
+
+    def _estimate_hessian_eigs(
+        self,
+        z: Tensor,
+        context: Tensor,
+        *,
+        probes: int = 3,
+    ) -> list[float]:
+        eigenvalues: list[float] = []
+        with torch.enable_grad():
+            z_param = z.detach().requires_grad_(True)
+            z_next = self.model.dynamics(z_param, context, self.model.memory_patterns)
+            energy, _ = self.model.energy_fn(z_param, z_next, self.model.memory_patterns)
+            grad = torch.autograd.grad(energy, z_param, create_graph=True)[0]
+            for _ in range(probes):
+                v = torch.randn_like(z_param)
+                v = v / v.norm().clamp_min(1e-8)
+                hv = torch.autograd.grad(grad, z_param, v, retain_graph=True)[0]
+                eigenvalues.append(float((v * hv).sum()))
+        return eigenvalues
+
+    @staticmethod
+    def _classify_eigenvalues(eigenvalues: Iterable[float]) -> str:
+        values = list(eigenvalues)
+        positives = sum(1 for v in values if v > 1e-3)
+        negatives = sum(1 for v in values if v < -1e-3)
+        total = len(values)
+        if total == positives:
+            return "minimum"
+        if total == negatives:
+            return "maximum"
+        if positives and negatives:
+            return "saddle"
+        return "flat"

--- a/src/unified_energy/training/__init__.py
+++ b/src/unified_energy/training/__init__.py
@@ -1,11 +1,14 @@
 """Training utilities for the unified energy framework."""
 
-from .objectives import energy_training_loss
+from .objectives import ObjectiveConfig, UnifiedTrainingObjective
 from .schedules import linear_schedule
-from .trainer import train_epoch
+from .trainer import CurriculumConfig, UnifiedModelTrainer, train_epoch
 
 __all__ = [
-    "energy_training_loss",
+    "ObjectiveConfig",
+    "UnifiedTrainingObjective",
     "linear_schedule",
+    "CurriculumConfig",
+    "UnifiedModelTrainer",
     "train_epoch",
 ]

--- a/src/unified_energy/training/objectives.py
+++ b/src/unified_energy/training/objectives.py
@@ -1,20 +1,138 @@
-"""Energy-based training objectives."""
+"""Training objectives for the unified Mamba-Hopfield-DEQ model."""
 from __future__ import annotations
 
-from typing import Dict
+from dataclasses import dataclass
+from typing import Dict, Tuple
 
+import torch
 from torch import Tensor
+from torch.nn import functional as F
 
-from ..core.energy import UnifiedEnergyFunction
+
+@dataclass(slots=True)
+class ObjectiveConfig:
+    """Weights for the composite training objective."""
+
+    task_weight: float = 1.0
+    energy_weight: float = 0.1
+    convergence_weight: float = 0.05
+    stability_weight: float = 0.01
+    contraction_target: float = 0.9
 
 
-def energy_training_loss(
-    energy_fn: UnifiedEnergyFunction,
-    z: Tensor,
-    z_next: Tensor,
-    memory_patterns: Tensor,
-) -> Dict[str, float]:
-    """Compute training loss components."""
+class UnifiedTrainingObjective:
+    """Combine task loss with energy- and convergence-aware regularisers."""
 
-    total, components = energy_fn(z, z_next, memory_patterns, compute_grad=True)
-    return {"loss": float(total.detach()), **components}
+    def __init__(self, config: ObjectiveConfig | None = None) -> None:
+        self.config = config or ObjectiveConfig()
+
+    def compute_loss(
+        self,
+        model,
+        batch: Tuple[Tensor, Tensor],
+        diagnostics: Dict[str, object],
+    ) -> Tuple[Tensor, Dict[str, float]]:
+        """Return the scalar loss and a dictionary of human-readable metrics."""
+
+        input_ids, target_ids = batch
+        logits = diagnostics.get("logits")
+        if logits is None:
+            logits = model(input_ids)
+
+        task_loss = F.cross_entropy(
+            logits.view(-1, logits.size(-1)),
+            target_ids.view(-1),
+            ignore_index=-100,
+        )
+        solver_info: Dict[str, object] = diagnostics.get("solver_info", {})
+        final_energy = self._extract_final_energy(solver_info)
+        energy_term = torch.as_tensor(
+            final_energy,
+            dtype=logits.dtype,
+            device=logits.device,
+        )
+        energy_loss = self.config.energy_weight * energy_term
+
+        iterations = float(solver_info.get("iterations", 0) or 0)
+        max_iter = float(getattr(model.solver.config, "max_iter", 1))
+        convergence_term = torch.as_tensor(
+            iterations / max(max_iter, 1.0),
+            dtype=logits.dtype,
+            device=logits.device,
+        )
+        convergence_loss = self.config.convergence_weight * convergence_term
+
+        lipschitz_constant = self._estimate_lipschitz(model, diagnostics)
+        stability_term = torch.as_tensor(
+            lipschitz_constant,
+            dtype=logits.dtype,
+            device=logits.device,
+        )
+        stability_loss = self.config.stability_weight * F.relu(
+            stability_term - self.config.contraction_target
+        )
+
+        total_loss = (
+            self.config.task_weight * task_loss
+            + energy_loss
+            + convergence_loss
+            + stability_loss
+        )
+
+        components = {
+            "total": float(total_loss.detach()),
+            "task": float(task_loss.detach()),
+            "energy": float(energy_loss.detach()),
+            "convergence": float(convergence_loss.detach()),
+            "stability": float(stability_loss.detach()),
+            "num_iterations": iterations,
+            "lipschitz_constant": lipschitz_constant,
+        }
+
+        energy_components = solver_info.get("energy_components")
+        if isinstance(energy_components, dict):
+            components["energy_components"] = {
+                key: float(value) if not isinstance(value, float) else value
+                for key, value in energy_components.items()
+            }
+        return total_loss, components
+
+    def _extract_final_energy(self, solver_info: Dict[str, object]) -> float:
+        if "final_energy" in solver_info:
+            value = solver_info["final_energy"]
+            if isinstance(value, Tensor):
+                return float(value.detach())
+            return float(value)
+        history = solver_info.get("energy_history")
+        if isinstance(history, (list, tuple)) and history:
+            return float(history[-1])
+        return 0.0
+
+    def _estimate_lipschitz(
+        self,
+        model,
+        diagnostics: Dict[str, object],
+        *,
+        num_samples: int = 3,
+        epsilon: float = 1e-2,
+    ) -> float:
+        context = diagnostics.get("context")
+        z_equilibrium = diagnostics.get("z_equilibrium")
+        if not isinstance(context, Tensor) or not isinstance(z_equilibrium, Tensor):
+            return 0.0
+        estimates: list[float] = []
+        for _ in range(num_samples):
+            delta = epsilon * torch.randn_like(z_equilibrium)
+            z_perturbed = z_equilibrium + delta
+            f_z = model.dynamics(z_equilibrium, context, model.memory_patterns)
+            f_z_pert = model.dynamics(z_perturbed, context, model.memory_patterns)
+            numerator = torch.norm(f_z_pert - f_z, dim=-1)
+            denominator = torch.norm(delta, dim=-1).clamp_min(1e-8)
+            estimate = torch.mean(numerator / denominator)
+            estimates.append(float(estimate.detach()))
+        if not estimates:
+            return 0.0
+        return float(sum(estimates) / len(estimates))
+
+
+__all__ = ["ObjectiveConfig", "UnifiedTrainingObjective"]

--- a/src/unified_energy/training/trainer.py
+++ b/src/unified_energy/training/trainer.py
@@ -1,16 +1,239 @@
-"""Prototype training loop for the unified energy model."""
+"""Curriculum-aware training loop for the unified model."""
 from __future__ import annotations
 
-from typing import Iterable
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
+import torch
 from torch import Tensor
+from torch.nn.utils import clip_grad_norm_
 
-from ..models.unified import UnifiedModel
+from .objectives import UnifiedTrainingObjective
+
+try:  # pragma: no cover - optional dependency
+    from tqdm.auto import tqdm
+except Exception:  # pragma: no cover - fallback when tqdm is unavailable
+    tqdm = None
+
+try:  # pragma: no cover - optional dependency
+    import wandb
+except Exception:  # pragma: no cover - fallback when wandb is unavailable
+    wandb = None  # type: ignore
 
 
-def train_epoch(model: UnifiedModel, batches: Iterable[Tensor]) -> None:
-    """Run a dummy epoch to validate interfaces."""
+@dataclass(slots=True)
+class CurriculumConfig:
+    """Schedules controlling solver depth and memory usage during training."""
 
-    for batch in batches:
-        z0, context, memory = batch
-        model(z0, context, memory)
+    warmup_steps: int = 500
+    max_iter_schedule: Sequence[int] = (10, 20, 30)
+    tolerance_schedule: Sequence[float] = (1e-2, 5e-3, 1e-3)
+    memory_enable_step: int = 1000
+
+    def __post_init__(self) -> None:
+        if len(self.max_iter_schedule) != len(self.tolerance_schedule):
+            msg = "max_iter_schedule and tolerance_schedule must have equal length"
+            raise ValueError(msg)
+        if self.warmup_steps < 0:
+            raise ValueError("warmup_steps must be non-negative")
+        if any(value <= 0 for value in self.max_iter_schedule):
+            raise ValueError("max_iter_schedule entries must be positive")
+        if any(value <= 0 for value in self.tolerance_schedule):
+            raise ValueError("tolerance_schedule entries must be positive")
+        if self.memory_enable_step < 0:
+            raise ValueError("memory_enable_step must be non-negative")
+
+
+class UnifiedModelTrainer:
+    """High-level trainer orchestrating optimisation and curriculum scheduling."""
+
+    def __init__(
+        self,
+        model,
+        *,
+        optimizer: torch.optim.Optimizer,
+        train_loader: Iterable[Tuple[Tensor, Tensor]],
+        val_loader: Optional[Iterable[Tuple[Tensor, Tensor]]] = None,
+        objective: Optional[UnifiedTrainingObjective] = None,
+        curriculum: Optional[CurriculumConfig] = None,
+        device: Optional[torch.device | str] = None,
+        log_wandb: bool = False,
+    ) -> None:
+        self.model = model
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model.to(self.device)
+        self.optimizer = optimizer
+        self.train_loader = train_loader
+        self.val_loader = val_loader
+        self.objective = objective or UnifiedTrainingObjective()
+        self.curriculum = curriculum or CurriculumConfig()
+        self.log_wandb = log_wandb and wandb is not None
+        self.step = 0
+        self.epoch = 0
+
+    def get_curriculum_params(self) -> Tuple[int, float, bool]:
+        """Return ``(max_iter, tolerance, memory_enabled)`` for the current step."""
+
+        if self.step < self.curriculum.warmup_steps:
+            return (
+                self.curriculum.max_iter_schedule[0],
+                self.curriculum.tolerance_schedule[0],
+                False,
+            )
+        stage = min(
+            len(self.curriculum.max_iter_schedule) - 1,
+            (self.step - self.curriculum.warmup_steps) // 2000,
+        )
+        max_iter = self.curriculum.max_iter_schedule[stage]
+        tolerance = self.curriculum.tolerance_schedule[stage]
+        memory_enabled = self.step >= self.curriculum.memory_enable_step
+        return max_iter, tolerance, memory_enabled
+
+    def train_step(self, batch: Tuple[Tensor, Tensor]) -> Dict[str, float]:
+        """Run a single optimisation step and return scalar metrics."""
+
+        self.model.train()
+        max_iter, tolerance, memory_enabled = self.get_curriculum_params()
+        self.model.solver.config.max_iter = max_iter
+        self.model.solver.config.tol_fixedpoint = tolerance
+        self.model.solver.config.tol_energy = tolerance
+
+        input_ids, target_ids = batch
+        input_ids = input_ids.to(self.device)
+        target_ids = target_ids.to(self.device)
+
+        logits, diagnostics = self.model(
+            input_ids,
+            update_memory=memory_enabled,
+            return_diagnostics=True,
+        )
+        diagnostics["logits"] = logits
+        loss, loss_components = self.objective.compute_loss(
+            self.model,
+            (input_ids, target_ids),
+            diagnostics,
+        )
+
+        self.optimizer.zero_grad()
+        loss.backward()
+        clip_grad_norm_(self.model.parameters(), max_norm=1.0)
+        self.optimizer.step()
+
+        if self.log_wandb and self.step % 10 == 0:
+            wandb.log(
+                {
+                    **loss_components,
+                    "curriculum/max_iter": max_iter,
+                    "curriculum/tolerance": tolerance,
+                    "curriculum/memory_enabled": int(memory_enabled),
+                    "step": self.step,
+                }
+            )
+        self.step += 1
+        return loss_components
+
+    def validate(self) -> Dict[str, float]:
+        """Evaluate the model on the validation loader."""
+
+        if self.val_loader is None:
+            return {}
+        self.model.eval()
+        total_loss = 0.0
+        total_converged = 0
+        iterations: List[float] = []
+        energy_histories: List[Sequence[float]] = []
+        num_batches = 0
+
+        with torch.no_grad():
+            for batch in self.val_loader:
+                input_ids, target_ids = batch
+                input_ids = input_ids.to(self.device)
+                target_ids = target_ids.to(self.device)
+                logits, diagnostics = self.model(
+                    input_ids,
+                    update_memory=False,
+                    return_diagnostics=True,
+                )
+                diagnostics["logits"] = logits
+                loss, _ = self.objective.compute_loss(
+                    self.model,
+                    (input_ids, target_ids),
+                    diagnostics,
+                )
+                total_loss += float(loss.detach())
+                solver_info = diagnostics.get("solver_info", {})
+                total_converged += int(bool(solver_info.get("converged", False)))
+                iterations.append(float(solver_info.get("iterations", 0) or 0))
+                history = solver_info.get("energy_history", [])
+                if isinstance(history, Sequence):
+                    energy_histories.append(history)
+                num_batches += 1
+
+        if num_batches == 0:
+            return {}
+
+        avg_iterations = sum(iterations) / max(len(iterations), 1)
+        stats = {
+            "val/loss": total_loss / num_batches,
+            "val/convergence_rate": total_converged / num_batches,
+            "val/avg_iterations": avg_iterations,
+        }
+        if iterations:
+            stats["val/median_iterations"] = float(torch.median(torch.tensor(iterations)).item())
+            stats["val/max_iterations"] = float(max(iterations))
+        if self.log_wandb:
+            wandb.log(stats)
+        return stats
+
+    def train(self, num_epochs: int) -> None:
+        """Full training loop with optional validation and checkpointing."""
+
+        loader = self.train_loader
+        for epoch in range(num_epochs):
+            self.epoch = epoch
+            iterator = loader
+            if tqdm is not None:
+                iterator = tqdm(loader, desc=f"Epoch {epoch + 1}/{num_epochs}")
+            for batch in iterator:
+                self.train_step(batch)
+            if self.val_loader is not None:
+                self.validate()
+
+    def save_checkpoint(self, path: str) -> None:
+        """Persist model, optimiser, and curriculum state."""
+
+        torch.save(
+            {
+                "model_state_dict": self.model.state_dict(),
+                "optimizer_state_dict": self.optimizer.state_dict(),
+                "step": self.step,
+                "epoch": self.epoch,
+                "memory_patterns": self.model.memory_patterns,
+            },
+            path,
+        )
+
+    def load_checkpoint(self, path: str) -> None:
+        """Restore training state from a checkpoint."""
+
+        checkpoint = torch.load(path, map_location=self.device)
+        self.model.load_state_dict(checkpoint["model_state_dict"])
+        self.optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
+        self.step = int(checkpoint.get("step", 0))
+        self.epoch = int(checkpoint.get("epoch", 0))
+        memory_patterns = checkpoint.get("memory_patterns")
+        if isinstance(memory_patterns, Tensor):
+            self.model.memory_patterns = memory_patterns.to(self.device)
+
+
+def train_epoch(
+    trainer: UnifiedModelTrainer,
+    *,
+    max_steps: Optional[int] = None,
+) -> None:
+    """Convenience wrapper to run a limited number of training steps."""
+
+    for step, batch in enumerate(trainer.train_loader):
+        trainer.train_step(batch)
+        if max_steps is not None and step + 1 >= max_steps:
+            break

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,131 @@
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn
+
+from unified_energy.experiments.theory import (
+    ConvergenceValidator,
+    EnergyLandscapeAnalyzer,
+    LandscapeConfig,
+    ValidationConfig,
+)
+
+
+class QuadraticEnergy:
+    def __call__(self, z: torch.Tensor, z_next: torch.Tensor, memory_patterns: torch.Tensor):
+        energy = 0.5 * torch.sum(z_next * z_next, dim=-1).mean()
+        components = {
+            "hopfield": float(energy),
+            "consistency": float(torch.sum((z - z_next) ** 2, dim=-1).mean()),
+            "regularization": 0.0,
+            "total": float(energy),
+        }
+        return energy, components
+
+    def energy_gradient(self, z: torch.Tensor, memory_patterns: torch.Tensor) -> torch.Tensor:
+        return z
+
+
+class LinearSolver:
+    def __init__(self, dynamics, energy_fn) -> None:
+        self.dynamics = dynamics
+        self.energy_fn = energy_fn
+        self.config = types.SimpleNamespace(max_iter=6, tol_fixedpoint=1e-4, tol_energy=1e-4)
+
+    def solve(self, z_init, context, memory_patterns):
+        z = z_init.clone()
+        info = {
+            "iterations": 0,
+            "energy_history": [],
+            "energy_components": {},
+        }
+        for iteration in range(self.config.max_iter):
+            z_next = self.dynamics(z, context, memory_patterns)
+            energy, components = self.energy_fn(z, z_next, memory_patterns)
+            grad_norm = torch.linalg.vector_norm(
+                self.energy_fn.energy_gradient(z_next, memory_patterns)
+            ).item()
+            fp_residual = torch.linalg.vector_norm(z_next - z).item()
+            info.update(
+                {
+                    "iterations": iteration + 1,
+                    "final_energy": float(energy.detach()),
+                    "final_energy_grad": grad_norm,
+                    "final_fp_residual": fp_residual,
+                    "energy_components": components,
+                }
+            )
+            info["energy_history"].append(float(energy.detach()))
+            if fp_residual < self.config.tol_fixedpoint:
+                info["converged"] = True
+                return z_next.detach(), info
+            z = z_next
+        info.setdefault("converged", False)
+        return z.detach(), info
+
+
+class DummyUnifiedModel(nn.Module):
+    def __init__(self, d_model: int = 4, memory_size: int = 6) -> None:
+        super().__init__()
+        self.d_model = d_model
+        self.register_buffer("memory_patterns", torch.zeros(memory_size, d_model))
+        self.energy_fn = QuadraticEnergy()
+        self.solver = LinearSolver(self.dynamics, self.energy_fn)
+
+    def dynamics(self, z: torch.Tensor, context: torch.Tensor, memory_patterns: torch.Tensor) -> torch.Tensor:
+        return 0.5 * z
+
+
+@pytest.fixture()
+def dummy_model() -> DummyUnifiedModel:
+    model = DummyUnifiedModel()
+    return model
+
+
+def test_convergence_validator_runs(dummy_model: DummyUnifiedModel) -> None:
+    validator = ConvergenceValidator(
+        dummy_model,
+        config=ValidationConfig(context_length=3, batch_size=1, max_perturbation_trials=2, stability_radius=0.05),
+        device="cpu",
+    )
+    contraction = validator.test_contraction_property(num_samples=4)
+    assert set(contraction) >= {"mean_lipschitz", "max_lipschitz", "is_contractive"}
+
+    energy = validator.test_energy_descent(num_trajectories=3, num_steps=5)
+    assert "monotonic_descent" in energy
+
+    stability = validator.test_fixed_point_stability(num_fixed_points=3, num_perturbations=2)
+    assert "stability_rate" in stability
+
+    lyapunov = validator.test_lyapunov_function(num_samples=3, horizon=4)
+    assert "lyapunov_rate" in lyapunov
+
+    summary = validator.run_all_tests()
+    assert "summary" in summary
+
+
+def test_energy_landscape_analyzer_shapes(dummy_model: DummyUnifiedModel) -> None:
+    analyzer = EnergyLandscapeAnalyzer(
+        dummy_model,
+        config=LandscapeConfig(context_length=3, grid_resolution=5, exploration_radius=0.2, basin_resolution=5, basin_radius=0.3),
+        device="cpu",
+    )
+    z_eq = torch.zeros(1, dummy_model.d_model)
+    context = torch.zeros(1, analyzer.config.context_length, dummy_model.d_model)
+    slice_data = analyzer.visualize_2d_slice(z_eq, context=context, resolution=5, radius=0.2)
+    assert slice_data["energy"].shape == (5, 5)
+
+    trajectories = analyzer.visualize_convergence_trajectories(num_trajectories=3, steps=4)
+    assert "trajectories_2d" in trajectories
+    assert len(trajectories["trajectories_2d"]) == 3
+
+    basin = analyzer.visualize_basin_of_attraction(z_eq, context=context, resolution=5, radius=0.2)
+    assert basin["convergence"].shape == (5, 5)
+
+    patterns = analyzer.visualize_memory_organization()
+    assert patterns["patterns_2d"].shape[1] == 2
+
+    critical_points = list(analyzer.analyze_critical_points(num_samples=2))
+    assert all("grad_norm" in point for point in critical_points)

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -1,0 +1,104 @@
+import types
+
+import pytest
+
+torch = pytest.importorskip("torch")
+from torch import nn
+
+from unified_energy.solvers.hybrid_solver import SolverConfig
+from unified_energy.training.objectives import UnifiedTrainingObjective
+from unified_energy.training.trainer import CurriculumConfig, UnifiedModelTrainer
+
+
+def _make_dummy_solver_config() -> SolverConfig:
+    return SolverConfig(max_iter=4, tol_fixedpoint=1e-3, tol_energy=1e-3, solver_type="alternating", anderson_memory=2, learning_rate=1e-2)
+
+
+class DummyModel(nn.Module):
+    def __init__(self, vocab_size: int = 8, d_model: int = 6, seq_len: int = 5) -> None:
+        super().__init__()
+        self.vocab_size = vocab_size
+        self.d_model = d_model
+        self.seq_len = seq_len
+        self.embedding = nn.Embedding(vocab_size, d_model)
+        self.output = nn.Linear(d_model, vocab_size)
+        self.memory_patterns = nn.Parameter(torch.zeros(7, d_model), requires_grad=False)
+        self.solver = types.SimpleNamespace(config=_make_dummy_solver_config())
+
+    def dynamics(self, z: torch.Tensor, context: torch.Tensor, memory_patterns: torch.Tensor) -> torch.Tensor:
+        return z + 0.1 * torch.tanh(z)
+
+    def forward(self, input_ids: torch.Tensor, *, update_memory: bool = True, return_diagnostics: bool = False):
+        context = self.embedding(input_ids)
+        z_equilibrium = context.mean(dim=1)
+        logits = self.output(context)
+        solver_info = {
+            "converged": True,
+            "iterations": 2,
+            "final_energy": 0.5,
+            "energy_components": {"hopfield": 0.2, "consistency": 0.2, "regularization": 0.1},
+            "final_fp_residual": 0.01,
+            "final_energy_grad": 0.02,
+            "energy_history": [0.7, 0.6, 0.5],
+        }
+        diagnostics = {
+            "solver_info": solver_info,
+            "z_equilibrium": z_equilibrium,
+            "energy_trajectory": solver_info["energy_history"],
+            "memory_usage": {},
+            "context": context,
+        }
+        if return_diagnostics:
+            return logits, diagnostics
+        return logits
+
+
+def test_training_objective_returns_all_components() -> None:
+    model = DummyModel()
+    objective = UnifiedTrainingObjective()
+    input_ids = torch.randint(0, model.vocab_size, (2, model.seq_len))
+    target_ids = input_ids.clone()
+    logits, diagnostics = model(input_ids, return_diagnostics=True)
+    diagnostics["logits"] = logits
+    loss, components = objective.compute_loss(model, (input_ids, target_ids), diagnostics)
+    assert loss.requires_grad
+    for key in ["total", "task", "energy", "convergence", "stability", "num_iterations", "lipschitz_constant"]:
+        assert key in components
+    assert "energy_components" in components
+    loss.backward()
+
+
+def test_trainer_step_and_validation_cycle() -> None:
+    torch.manual_seed(0)
+    model = DummyModel()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    train_data = [
+        (
+            torch.randint(0, model.vocab_size, (2, model.seq_len)),
+            torch.randint(0, model.vocab_size, (2, model.seq_len)),
+        )
+        for _ in range(3)
+    ]
+    val_data = [
+        (
+            torch.randint(0, model.vocab_size, (2, model.seq_len)),
+            torch.randint(0, model.vocab_size, (2, model.seq_len)),
+        )
+    ]
+    trainer = UnifiedModelTrainer(
+        model,
+        optimizer=optimizer,
+        train_loader=train_data,
+        val_loader=val_data,
+        curriculum=CurriculumConfig(warmup_steps=0, max_iter_schedule=(3, 5), tolerance_schedule=(1e-2, 5e-3), memory_enable_step=0),
+    )
+    max_iter, tolerance, memory_enabled = trainer.get_curriculum_params()
+    assert max_iter == 3
+    assert pytest.approx(tolerance) == 1e-2
+    assert memory_enabled
+    metrics = trainer.train_step(train_data[0])
+    assert "total" in metrics
+    val_stats = trainer.validate()
+    assert "val/loss" in val_stats
+    assert "val/convergence_rate" in val_stats
+


### PR DESCRIPTION
## Summary
- add a `ConvergenceValidator` with configurable contraction, energy descent, stability, and Lyapunov checks
- introduce an `EnergyLandscapeAnalyzer` for energy slices, convergence trajectories, basins of attraction, and memory projections
- document the new tooling and cover it with a unit test harness built on a dummy unified model

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dff543b0e0832b89a3f404bae5193d